### PR TITLE
Add explicit underline to package links with tput

### DIFF
--- a/cmd/nix-search/main.go
+++ b/cmd/nix-search/main.go
@@ -60,24 +60,21 @@ func root(c *cobra.Command, args []string) {
 	o, _ := os.Stdout.Stat()
 	isTerminal := (o.Mode() & os.ModeCharDevice) == os.ModeCharDevice
 
+	var startUnderline string
+	var endUnderline string
 	// tput is used to set underline formatting in the shell. But if it doesn't exist, do nothing
 	_, err = exec.LookPath("tput")
-	hasTput := err != nil
-	if !hasTput {
-		return
+	if err == nil {
+		bytes, _ := exec.Command("tput", "smul").Output()
+		startUnderline = string(bytes)
+		bytes, _ = exec.Command("tput", "rmul").Output()
+		endUnderline = string(bytes)
 	}
 
 	for _, pkg := range packages {
 		if isTerminal {
 			url := fmt.Sprintf(`https://search.nixos.org/packages?channel=%s&show=%s`, channel, pkg.AttrName)
-			// Ignore errors from formatting commands, they should not crash the tool.
-			if hasTput {
-				_ = exec.Command("tput", "smul").Run()
-			}
-			fmt.Printf("%s", escapes.Link(url, pkg.AttrName))
-			if hasTput {
-				_ = exec.Command("tput", "rmul").Run()
-			}
+			fmt.Printf("%s%s%s", startUnderline, escapes.Link(url, pkg.AttrName), endUnderline)
 		} else {
 			fmt.Printf("%s", pkg.AttrName)
 		}


### PR DESCRIPTION
The package names link to NixOS Search, but not all terminals have an underline affordance for links. This PR updates the tool to explicitly underline the links so that it is clear that the package names are links in all terminals.

Before

![image](https://user-images.githubusercontent.com/51880422/220168414-b7829efc-a70a-47fd-9f50-60e5309c7d10.png)

After

![image](https://user-images.githubusercontent.com/51880422/220168364-d4645899-2873-4a7c-b658-02f15e89afec.png)
