### PR TITLE
Corrects 'run it' instructions to include '--' delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ docker pull ghcr.io/peterldowns/nix-search-cli:latest
 Nix (flakes):
 ```bash
 # run it
-nix run github:peterldowns/nix-search-cli --help
+nix run github:peterldowns/nix-search-cli -- --help
 # install it
 nix profile install github:peterldowns/nix-search-cli --refresh
 ```


### PR DESCRIPTION
`nix run` requires the `--` delimiter or else the `--help` command gets interpreted as being attached to `run` and not `nix-search-cli`