### PR TITLE
Update flake.lock to fix issue on MacOS Tahoe

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Nix
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711912510,
-        "narHash": "sha256-m/FBphwnP4JOCOIrPDVt7vGlf0rmN2w+yaeU8KzoMD8=",
+        "lastModified": 1761752004,
+        "narHash": "sha256-z83uhYagfW6ZnH5Svvaxx6O0a305sBLGCCJZBJnMD9w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b8d649e4b26df1701b40dd81342f38dbc29382b8",
+        "rev": "ddf56acbeb53825b79b82c13a657806774bfd137",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Running this as a flake on tahoe produces the error: 
```
missing LC_UUID load command in /nix/store/z7syn0ajm5x21cri8vvbqqdbs7wqz97l-nix-search-v0.3-/bin/nix-search
```
Which is due to a [change in behavior](https://developer.apple.com/documentation/technotes/tn3178-checking-for-and-resolving-build-uuid-problems) on tahoe and is referenced in [this stackoverflow post](https://developer.apple.com/documentation/technotes/tn3178-checking-for-and-resolving-build-uuid-problems) as something that is fixed in newer versions of go.

Updating the reference to nixpkgs seems to fix the issue.

Can be reproduced (on tahoe) with `nix run` on the previous lockfile, and I have verified that it is fixed with the new lockfile